### PR TITLE
Convert ES6 function to ES5

### DIFF
--- a/view/frontend/web/js/price-slider.js
+++ b/view/frontend/web/js/price-slider.js
@@ -22,7 +22,7 @@ define([
             this.build();
         },
 
-        constructUrl(min, max) {
+        constructUrl: function(min, max) {
             var url = window.location.href;
             var query = url.split('?');
             var prefix = 'price=';


### PR DESCRIPTION
The price slider was erroring in IE11 due to an ES6 function being used, this now uses the ES5 syntax.