### PR TITLE
Namespace touch-punch to Price Slider extension

### DIFF
--- a/view/frontend/requirejs-config.js
+++ b/view/frontend/requirejs-config.js
@@ -1,6 +1,11 @@
 var config = {
     paths: {
         'priceSlider': 'Space48_PriceSlider/js/price-slider',
-        'jquery/ui/touch-punch': 'Space48_PriceSlider/js/lib/jquery.ui.touch-punch.min'
+        'priceSlider/touch-punch': 'Space48_PriceSlider/js/lib/jquery.ui.touch-punch.min'
+    },
+    shim: {
+        'priceSlider/touch-punch': {
+            deps: ['jquery/ui']
+        }
     }
 };

--- a/view/frontend/web/js/price-slider.js
+++ b/view/frontend/web/js/price-slider.js
@@ -2,7 +2,7 @@ define([
     'uiComponent',
     'jquery',
     'jquery/ui',
-    'jquery/ui/touch-punch',
+    'priceSlider/touch-punch',
     'domReady!'
 ], function (Component, $) {
 


### PR DESCRIPTION
Just specifying the requirement as jquery/ui/touch-punch appears to
trigger some default Magento functionality that tries to load from
/jquery/compat/touch-punch.js.